### PR TITLE
set csv file to example.csv

### DIFF
--- a/main.py
+++ b/main.py
@@ -378,6 +378,7 @@ def wilcoxon_holm(alpha=0.05, df_perf=None):
     # return the p-values and the average ranks
     return p_values, average_ranks, max_nb_datasets
 
-df_perf = pd.read_csv('DefaultvsTunedvsEnsembleCritDiffAcc.csv',index_col=False)
+
+df_perf = pd.read_csv('example.csv', index_col=False)
 
 draw_cd_diagram(df_perf=df_perf, title='Accuracy', labels=True)


### PR DESCRIPTION
The file DefaultvsTunedvsEnsembleCritDiffAcc.csv doesn't seem to be part of the repository and the README.md mentions using the example.csv file, so i guess that file should be used to create an example cd diagram.